### PR TITLE
Edge case fixes

### DIFF
--- a/handler.py
+++ b/handler.py
@@ -118,12 +118,15 @@ def parrot(event, context):
         cluster        = event['detail']['requestParameters']['cluster']
         instance_id    = event['detail']['responseElements']['containerInstance']['ec2InstanceId']
         instance_uuid  = event['detail']['responseElements']['containerInstance']['containerInstanceArn'].split('/')[1]
-        version_docker = event['detail']['responseElements']['containerInstance']['versionInfo']['dockerVersion'].split(' ')[1]
-        version_agent  = event['detail']['responseElements']['containerInstance']['versionInfo']['agentVersion']
 
         instance_link  = 'https://console.aws.amazon.com/ecs/home?region=' + os.environ['AWS_DEFAULT_REGION'] +'#/clusters/'+ cluster +'/containerInstances/' + instance_uuid
+        message        = cluster +" member <"+ instance_link +"|"+ instance_id +"> started"
 
-        message        = cluster +" member <"+ instance_link +"|"+ instance_id +"> started ECS agent "+ version_agent +" with Docker "+ version_docker
+        if len(event['detail']['responseElements']['containerInstance']['versionInfo']) > 0:
+            version_docker = event['detail']['responseElements']['containerInstance']['versionInfo']['dockerVersion'].split(' ')[1]
+            version_agent  = event['detail']['responseElements']['containerInstance']['versionInfo']['agentVersion']
+
+            message += " ECS agent "+ version_agent +" with Docker "+ version_docker
 
         # ECS machine replacements are not overly common, so we should ignore
         # quiet - however we may change this in future when we roll autoscaling.

--- a/handler.py
+++ b/handler.py
@@ -90,6 +90,13 @@ def parrot(event, context):
                 if (uptime_delta.total_seconds() <= 300):
                     ignore_quiet = True
 
+                for container in task_details['containers']:
+                    if 'reason' in container and container['reason'].find('OutOfMemoryError') == 0:
+                        # If a container has a stopped reason beginning with
+                        # OutOfMemoryError, then we should know about it,
+                        # regardless of how long the task had been running for.
+                        ignore_quiet = True
+
         # Provide a link to the logs for each container inside the task for
         # handy debugging and following. Particularly useful for stopped tasks
         # but can also be useful for newly launched tasks

--- a/handler.py
+++ b/handler.py
@@ -82,13 +82,15 @@ def parrot(event, context):
         # flappy systems.
         if event['detail']['requestParameters']['status'] == "STOPPED":
             if task_details:
-                uptime_delta = task_details['stoppedAt'] - task_details['startedAt']
-                message += ' (Ran for '+ str(int(uptime_delta.total_seconds())/60) +' minutes)'
+                # startedAt may not be in task_details if the task never started
+                if 'startedAt' in task_details:
+                    uptime_delta = task_details['stoppedAt'] - task_details['startedAt']
+                    message += ' (Ran for '+ str(int(uptime_delta.total_seconds())/60) +' minutes)'
 
-                # We want to catch any services stuck in reboots (eg unable to
-                # start up successfully)
-                if (uptime_delta.total_seconds() <= 300):
-                    ignore_quiet = True
+                    # We want to catch any services stuck in reboots (eg unable to
+                    # start up successfully)
+                    if (uptime_delta.total_seconds() <= 300):
+                        ignore_quiet = True
 
                 for container in task_details['containers']:
                     if 'reason' in container and container['reason'].find('OutOfMemoryError') == 0:


### PR DESCRIPTION
Currently if a container is terminated (after running for five minutes) due to hitting memory limit, it is not reported. So check for OutOfMemoryError message and enable ignore_quiet.

There are cases where startedAt does not exist in task_details. eg. failed to start due to Docker image/tag not found.

We're now seeing an empty versionInfo value in RegisterContainerInstance API calls. Possibly an ECS agent issue - for now just skip version info in the message if it isn't there.